### PR TITLE
add league id to sim event

### DIFF
--- a/src/db/events.ts
+++ b/src/db/events.ts
@@ -9,5 +9,6 @@ export type MaddenBroadcastEvent = { title: string, video: string }
 export type YoutubeBroadcastEvent = { video: string }
 export type AddChannelEvent = { channel_id: string, discord_server: string }
 export type RemoveChannelEvent = { channel_id: string, discord_server: string }
-export type ConfirmedSim = { confirmedUsers: UserId[], requestedUsers: UserId[], result: SimResult, scheduleId: number, seasonIndex: number, week: number, homeUser?: UserId, awayUser?: UserId }
+// [March 8]] league id was added later once we found out that schedule ids can be shared between leagues
+export type ConfirmedSim = { confirmedUsers: UserId[], requestedUsers: UserId[], result: SimResult, scheduleId: number, seasonIndex: number, week: number, homeUser?: UserId, awayUser?: UserId, leagueId?: string }
 export type DiscordLeagueConnectionEvent = { guildId: string, leagueId: string }

--- a/src/discord/commands/game_channels.ts
+++ b/src/discord/commands/game_channels.ts
@@ -30,9 +30,9 @@ function createSimMessage(sim: ConfirmedSim): string {
 }
 
 
-export function formatScoreboard(week: number, seasonIndex: number, games: MaddenGame[], teams: TeamList, sims: ConfirmedSim[]) {
+export function formatScoreboard(week: number, seasonIndex: number, games: MaddenGame[], teams: TeamList, sims: ConfirmedSim[], leagueId: string) {
   const gameToSim = new Map<number, ConfirmedSim>()
-  sims.forEach(sim => gameToSim.set(sim.scheduleId, sim))
+  sims.filter(s => s.leagueId ? s.leagueId === leagueId : true).forEach(sim => gameToSim.set(sim.scheduleId, sim))
   const scoreboardGames = games.sort((g1, g2) => g1.scheduleId - g2.scheduleId).map(game => {
     const simMessage = gameToSim.has(game.scheduleId) ? ` (${createSimMessage(gameToSim.get(game.scheduleId)!)})` : ""
     const awayTeamName = teams.getTeamForId(game.awayTeamId)?.displayName
@@ -200,7 +200,7 @@ async function createGameChannels(client: DiscordClient, db: Firestore, token: s
     })
 
     const season = weekSchedule[0].seasonIndex
-    const scoreboardMessage = formatScoreboard(week, season, weekSchedule, teams, [])
+    const scoreboardMessage = formatScoreboard(week, season, weekSchedule, teams, [], leagueId)
     const res = await client.requestDiscord(`channels/${settings.commands.game_channel?.scoreboard_channel.id}/messages`, { method: "POST", body: { content: scoreboardMessage, allowed_mentions: { parse: [] } } })
     const message = await res.json() as APIMessage
     const weeklyState: WeekState = { week: week, seasonIndex: season, scoreboard: { id: message.id, id_type: DiscordIdType.MESSAGE }, channel_states: channelsMap }

--- a/src/discord/notifier.ts
+++ b/src/discord/notifier.ts
@@ -73,7 +73,7 @@ function createNotifier(client: DiscordClient, guildId: string, settings: League
     const homeTeamId = teams.getTeamForId(game.homeTeamId).teamId
     const awayUser = latestAssignents[awayTeamId]?.discord_user
     const homeUser = latestAssignents[homeTeamId]?.discord_user
-    const event: SnallabotEvent<ConfirmedSim> = { key: guildId, event_type: "CONFIRMED_SIM", result: result, scheduleId: gameChannel.scheduleId, requestedUsers: requestedUsers, confirmedUsers: confirmedUsers, week: week, seasonIndex: season }
+    const event: SnallabotEvent<ConfirmedSim> = { key: guildId, event_type: "CONFIRMED_SIM", result: result, scheduleId: gameChannel.scheduleId, requestedUsers: requestedUsers, confirmedUsers: confirmedUsers, week: week, seasonIndex: season, leagueId: leagueId }
     if (awayUser) {
       event.awayUser = awayUser
     }

--- a/src/discord/routes.ts
+++ b/src/discord/routes.ts
@@ -117,7 +117,7 @@ async function updateScoreboard(leagueSettings: LeagueSettings, guildId: string,
   const teams = await MaddenClient.getLatestTeams(leagueId)
   const games = await MaddenClient.getWeekScheduleForSeason(leagueId, week, seasonIndex)
   const sims = await EventDB.queryEvents<ConfirmedSim>(guildId, "CONFIRMED_SIM", new Date(0), { week: week, seasonIndex: seasonIndex }, 30)
-  const message = formatScoreboard(week, seasonIndex, games, teams, sims)
+  const message = formatScoreboard(week, seasonIndex, games, teams, sims, leagueId)
   try {
     await prodClient.requestDiscord(`channels/${scoreboard_channel.id}/messages/${scoreboard.id}`, { method: "PATCH", body: { content: message, allowed_mentions: { parse: [] } } })
   } catch (e) {


### PR DESCRIPTION
there are schedule ids shared across leagues, this will prevent them if a league transitions to a new one