### PR TITLE
Reduce memory usage on large exports

### DIFF
--- a/src/dashboard/ea_client.ts
+++ b/src/dashboard/ea_client.ts
@@ -581,7 +581,6 @@ export async function exporterForLeague(leagueId: number, context: ExportContext
       const destinations = Object.values(contextualExports)
       const leagueData = { weeks: [] } as any
       const leagueInfoRequests = [] as Promise<any>[]
-      const dataRequests = [] as Promise<any>[]
       function toStage(stage: number): Stage {
         return stage === 0 ? Stage.PRESEASON : Stage.SEASON
       }
@@ -618,9 +617,6 @@ export async function exporterForLeague(leagueId: number, context: ExportContext
           await exportData(weeklyData as ExportData, contextualExports, `${leagueId}`, client.getSystemConsole())
         }
       }
-
-      // avoid using too much memory, process weekly data first then team rosters
-      await Promise.all(dataRequests.map(request => staggeringCall(request, 50)))
       if (destinations.some(e => e.rosters)) {
         let teamRequests = [] as Promise<any>[]
         let teamData: TeamData = { roster: {} }


### PR DESCRIPTION
large all weeks exports can be really slow due to memory overhead of getting all the stats for the entire year and writing them. Start batching the weeks in groups of 4 to slightly slow down that load to lead to more stable export process