### PR TITLE
fix bug with game channels clearing and creating at the same time

### DIFF
--- a/src/discord/commands/game_channels.ts
+++ b/src/discord/commands/game_channels.ts
@@ -225,7 +225,11 @@ async function clearGameChannels(client: DiscordClient, db: Firestore, token: st
   try {
     await client.editOriginalInteraction(token, { content: `Clearing Game Channels...` })
     const weekStates = settings.commands.game_channel?.weekly_states || {}
-    const channelsToClear = Object.entries(weekStates).flatMap(entry => {
+    const weekStatesWithChannels = Object.fromEntries(Object.entries(weekStates).filter(entry => {
+      const weekState = entry[1]
+      return weekState?.channel_states
+    }))
+    const channelsToClear = Object.entries(weekStatesWithChannels).flatMap(entry => {
       const weekState = entry[1]
       return Object.values(weekState?.channel_states || {})
     }).map(channelStates => {
@@ -250,7 +254,7 @@ async function clearGameChannels(client: DiscordClient, db: Firestore, token: st
         }
       }))
     }
-    await Promise.all(Object.values(weekStates).map(async weekState => {
+    await Promise.all(Object.values(weekStatesWithChannels).map(async weekState => {
       await LeagueSettingsDB.deleteGameChannels(guild_id, weekState.week, weekState.seasonIndex)
     }))
     await client.editOriginalInteraction(token, { content: `Game Channels Cleared` })


### PR DESCRIPTION
if it takes a whlie to clear game channels, you can get in a state where the new ones you created arent there anymore. this fixes this issue by making sure we dont read and modify the same state