### PR TITLE
Cache teams

### DIFF
--- a/src/db/madden_db.ts
+++ b/src/db/madden_db.ts
@@ -409,6 +409,11 @@ const MaddenDB: MaddenDB = {
     EventDB.on(event_type, notifier)
   },
   getLatestTeams: async function(leagueId: string): Promise<TeamList> {
+    let e = new Error();
+    let frame = e?.stack?.split("\n")[2]; // change to 3 for grandparent func
+    let lineNumber = frame?.split(":")?.reverse()[1];
+    let functionName = frame?.split(" ")[5];
+    console.log(functionName + ":" + lineNumber + " ")
     const cachedTeamDocs = teamCache.get(leagueId) as Record<string, StoredEvent<Team>>
     if (cachedTeamDocs) {
       console.log(`used cached data ${cachedTeamDocs}`)

--- a/src/db/madden_db.ts
+++ b/src/db/madden_db.ts
@@ -409,14 +409,8 @@ const MaddenDB: MaddenDB = {
     EventDB.on(event_type, notifier)
   },
   getLatestTeams: async function(leagueId: string): Promise<TeamList> {
-    let e = new Error();
-    let frame = e?.stack?.split("\n")[2]; // change to 3 for grandparent func
-    let lineNumber = frame?.split(":")?.reverse()[1];
-    let functionName = frame?.split(" ")[5];
-    console.log(functionName + ":" + lineNumber + " ")
     const cachedTeamDocs = teamCache.get(leagueId) as Record<string, StoredEvent<Team>>
     if (cachedTeamDocs) {
-      console.log(`used cached data ${cachedTeamDocs}`)
       return createTeamList(Object.values(cachedTeamDocs))
     } else {
       const teamDocs = await db.collection("madden_data26").doc(leagueId).collection(MaddenEvents.MADDEN_TEAM).get()

--- a/src/db/madden_db.ts
+++ b/src/db/madden_db.ts
@@ -416,7 +416,7 @@ const MaddenDB: MaddenDB = {
     } else {
       const teamDocs = await db.collection("madden_data26").doc(leagueId).collection(MaddenEvents.MADDEN_TEAM).get()
       const teams = teamDocs.docs.map(d => convertDate(d.data()) as StoredEvent<Team>)
-      teamCache.set(leagueId, Object.fromEntries(teams.map(t => [t.teamId, t])))
+      teamCache.set(leagueId, Object.fromEntries(teams.map(t => [`${t.teamId}`, t])))
       return createTeamList(teams)
     }
   },

--- a/src/db/madden_db.ts
+++ b/src/db/madden_db.ts
@@ -4,6 +4,10 @@ import db from "./firebase"
 import EventDB, { EventNotifier, SnallabotEvent, StoredEvent, notifiers } from "./events_db"
 import { DefensiveStats, GameResult, KickingStats, MADDEN_SEASON, MaddenGame, POSITION_GROUP, PassingStats, Player, PuntingStats, ReceivingStats, RushingStats, Standing, Team, TeamStats, dLinePositions, dbPositions, oLinePositions } from "../export/madden_league_types"
 import { TeamAssignments } from "../discord/settings_db"
+import NodeCache from "node-cache"
+
+// getting Teams is a high request rate, by caching we can avoid calling the data when it hasnt changed
+const teamCache = new NodeCache()
 
 type HistoryUpdate<ValueType> = { oldValue: ValueType, newValue: ValueType }
 type History = { [key: string]: HistoryUpdate<any>, }
@@ -405,8 +409,16 @@ const MaddenDB: MaddenDB = {
     EventDB.on(event_type, notifier)
   },
   getLatestTeams: async function(leagueId: string): Promise<TeamList> {
-    const teamDocs = await db.collection("madden_data26").doc(leagueId).collection(MaddenEvents.MADDEN_TEAM).get()
-    return createTeamList(teamDocs.docs.map(d => convertDate(d.data()) as StoredEvent<Team>))
+    const cachedTeamDocs = teamCache.get(leagueId) as Record<string, StoredEvent<Team>>
+    if (cachedTeamDocs) {
+      console.log(`used cached data ${cachedTeamDocs}`)
+      return createTeamList(Object.values(cachedTeamDocs))
+    } else {
+      const teamDocs = await db.collection("madden_data26").doc(leagueId).collection(MaddenEvents.MADDEN_TEAM).get()
+      const teams = teamDocs.docs.map(d => convertDate(d.data()) as StoredEvent<Team>)
+      teamCache.set(leagueId, Object.fromEntries(teams.map(t => [t.teamId, t])))
+      return createTeamList(teams)
+    }
   },
   getLatestWeekSchedule: async function(leagueId: string, week: number) {
     const [weekDocs, teamList] = await Promise.all([db.collection("madden_data26").doc(leagueId).collection(MaddenEvents.MADDEN_SCHEDULE).where("weekIndex", "==", week - 1)
@@ -818,3 +830,12 @@ const MaddenDB: MaddenDB = {
 }
 
 export default MaddenDB
+
+// when teams are updated, just delete the entry in the cache for now.
+// simple is best? can revisit if we want to do event driven updates to it
+MaddenDB.on<Team>(MaddenEvents.MADDEN_TEAM, async events => {
+  const leagueId = events?.[0].key
+  if (leagueId) {
+    teamCache.del(leagueId)
+  }
+})

--- a/src/discord/commands/schedule.ts
+++ b/src/discord/commands/schedule.ts
@@ -129,7 +129,6 @@ async function showTeamSchedule(token: string, client: DiscordClient,
       MaddenClient.getLatestTeams(league),
       MaddenClient.getAllWeeks(league)
     ])
-    const sims = await getSims(league, requestedSeason)
 
     const schedule = settledPromise[0].status === "fulfilled" ? settledPromise[0].value : []
     if (settledPromise[1].status !== "fulfilled") {
@@ -148,16 +147,6 @@ async function showTeamSchedule(token: string, client: DiscordClient,
       teams.getTeamForId(game.awayTeamId).teamId === teamId || teams.getTeamForId(game.homeTeamId).teamId === teamId
     ).sort((a, b) => a.scheduleId - b.scheduleId)
 
-    const scheduleKeys = new Set(
-      teamSchedule.map(game => `${game.scheduleId}-${game.seasonIndex}`)
-    )
-
-    const teamSims = sims.filter(sim =>
-      scheduleKeys.has(`${sim.scheduleId}-${sim.seasonIndex}`)
-    )
-
-    const gameToSim = new Map<number, ConfirmedSimV2>()
-    teamSims.forEach(sim => gameToSim.set(sim.scheduleId, sim))
 
     const selectedTeam = teams.getTeamForId(teamId)
     if (!selectedTeam) {
@@ -169,6 +158,17 @@ async function showTeamSchedule(token: string, client: DiscordClient,
       weekToGameMap.set(game.weekIndex + 1, game)
     })
     const season = teamSchedule?.[0]?.seasonIndex >= 0 ? teamSchedule[0].seasonIndex : requestedSeason != null ? requestedSeason : 0
+    const sims = await getSims(league, season)
+    const scheduleKeys = new Set(
+      teamSchedule.map(game => `${game.scheduleId}-${game.seasonIndex}`)
+    )
+
+    const teamSims = sims.filter(sim =>
+      scheduleKeys.has(`${sim.scheduleId}-${sim.seasonIndex}`)
+    )
+
+    const gameToSim = new Map<number, ConfirmedSimV2>()
+    teamSims.forEach(sim => gameToSim.set(sim.scheduleId, sim))
 
     const scheduleLines = []
     const weeksToShow = allWeeks.filter(ws => ws.seasonIndex === season).map(ws => ws.weekIndex + 1).sort((a, b) => a - b)


### PR DESCRIPTION
This was super interesting. Because of duplicate teams, we kind of need to know teams anywhere we use a teamId (so we can map it to the latest). Basically, we call getLatestTeams almost everywhere. Even a simple call turns into maybe 30 requests for this one function. I was surprised by this, but the more I thought about it, this was a mistake to do it this way. A lot of these functions should have taken a TeamList and not make the call themselves. Very dangerous indeed

who has the time to fix all that tho, so lets cache the teams for now. Duplicate calls will now be served through the cache and our reads will go down dramatically. Not happy, but ill take the optimization either way. This was going to be called a lot regardless tbh. 